### PR TITLE
refactor plugin registration

### DIFF
--- a/src/Labrador/CoreEngine.php
+++ b/src/Labrador/CoreEngine.php
@@ -82,7 +82,6 @@ class CoreEngine implements Engine {
      */
     public function run() {
         try {
-            $this->pluginManager->registerBooter();
             $this->emitter->emit(self::PLUGIN_BOOT_EVENT, [new Event\PluginBootEvent(), $this]);
             $this->emitter->emit(self::APP_EXECUTE_EVENT, [new Event\AppExecuteEvent(), $this]);
         } catch (\Exception $exception) {

--- a/test/Labrador/Stub/EventsRegisteredPlugin.php
+++ b/test/Labrador/Stub/EventsRegisteredPlugin.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace Labrador\Stub;
+
+use Evenement\EventEmitterInterface;
+use Labrador\Plugin\EventAwarePlugin;
+
+class EventsRegisteredPlugin implements EventAwarePlugin {
+
+    private $called = false;
+
+    public function wasCalled() {
+        return $this->called;
+    }
+
+    /**
+     * Register the event listeners your Plugin responds to.
+     *
+     * @param EventEmitterInterface $emitter
+     * @return void
+     */
+    public function registerEventListeners(EventEmitterInterface $emitter) {
+        $this->called = true;
+    }
+
+    /**
+     * Return the name of the plugin; this name should match /[A-Za-z0-9\.\-\_]/
+     *
+     * @return string
+     */
+    public function getName() {
+        // TODO: Implement getName() method.
+    }
+
+    /**
+     * Perform any actions that should be
+     */
+    public function boot() {
+        // TODO: Implement boot() method.
+    }
+
+}

--- a/test/Labrador/Stub/ServicesRegisteredPlugin.php
+++ b/test/Labrador/Stub/ServicesRegisteredPlugin.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Labrador\Stub;
+
+use Auryn\Injector;
+use Labrador\Plugin\ServiceAwarePlugin;
+
+class ServicesRegisteredPlugin implements ServiceAwarePlugin {
+
+    private $called = false;
+
+    public function wasCalled() {
+        return $this->called;
+    }
+
+    /**
+     * Return the name of the plugin; this name should match /[A-Za-z0-9\.\-\_]/
+     *
+     * @return string
+     */
+    public function getName() {
+        return 'services-plugin-stub';
+    }
+
+    /**
+     * Perform any actions that should be
+     */
+    public function boot() {
+        // TODO: Implement boot() method.
+    }
+
+    /**
+     * Register any services that the Plugin provides.
+     *
+     * @param Injector $injector
+     * @return void
+     */
+    public function registerServices(Injector $injector) {
+        $this->called = true;
+    }
+}


### PR DESCRIPTION
Changes the plugin registration to ensure that all plugins have their
services registered before their events are registered and before they
are booted. This ensures that if a Plugin requires on the service
provided by another Plugin that service is appropriately registered in
the container before it is accessed.